### PR TITLE
Internal logging

### DIFF
--- a/derelict.gemspec
+++ b/derelict.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "log4r"
   spec.add_runtime_dependency "shell-executer"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -1,4 +1,5 @@
 require "derelict/version"
+require "log4r"
 require "shell/executer"
 
 module Derelict
@@ -10,6 +11,11 @@ module Derelict
 
   # Make functions accessible by Derelict.foo and private when included
   module_function
+
+  # Retrieves the base Log4r::Logger used by Derelict
+  def logger
+    ::Log4r::Logger["derelict"] || ::Log4r::Logger.new("derelict")
+  end
 
   # Creates a new Derelict instance for a Vagrant installation
   #

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -7,16 +7,15 @@ module Derelict
   autoload :Exception,      "derelict/exception"
   autoload :Instance,       "derelict/instance"
   autoload :Log4r,          "derelict/log4r"
+  autoload :Logger,         "derelict/logger"
   autoload :Parser,         "derelict/parser"
   autoload :VirtualMachine, "derelict/virtual_machine"
 
   # Make functions accessible by Derelict.foo and private when included
   module_function
 
-  # Retrieves the base Log4r::Logger used by Derelict
-  def logger
-    ::Log4r::Logger["derelict"] || ::Log4r::Logger.new("derelict")
-  end
+  # Include "logger" method to get a logger for this class
+  extend Logger
 
   # Creates a new Derelict instance for a Vagrant installation
   #
@@ -24,5 +23,32 @@ module Derelict
   #           to Instance::DEFAULT_PATH)
   def instance(path = Instance::DEFAULT_PATH)
     Instance.new(path).validate!
+  end
+
+  # Enables (or disables) Derelict's debug mode
+  #
+  # When in debug mode, Derelict will log to stderr. The debug level
+  # can be controlled as well (which affects the verbosity of the
+  # logging).
+  def debug!(options = {})
+    ::Log4r::Logger["root"] # creates the level constants (INFO, etc).
+
+    options = {
+      :enabled => true,
+      :level => ::Log4r::INFO,
+    }.merge options
+
+    if options[:enabled]
+      stderr = ::Log4r::Outputter.stderr
+      logger.add stderr unless logger.outputters.include? stderr
+      logger.level = options[:level]
+      logger.info "enabling debug mode"
+    else
+      logger.info "disabling debug mode"
+      logger.remove "stderr"
+      logger.level = ::Log4r::OFF
+    end
+
+    self
   end
 end

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -22,6 +22,7 @@ module Derelict
   #   * path: The path to the Vagrant installation (optional, defaults
   #           to Instance::DEFAULT_PATH)
   def instance(path = Instance::DEFAULT_PATH)
+    logger.info "Creating and validating new instance for '#{path}'"
     Instance.new(path).validate!
   end
 

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -6,6 +6,7 @@ module Derelict
   autoload :Connection,     "derelict/connection"
   autoload :Exception,      "derelict/exception"
   autoload :Instance,       "derelict/instance"
+  autoload :Log4r,          "derelict/log4r"
   autoload :Parser,         "derelict/parser"
   autoload :VirtualMachine, "derelict/virtual_machine"
 

--- a/lib/derelict/connection.rb
+++ b/lib/derelict/connection.rb
@@ -80,7 +80,7 @@ module Derelict
       # Handles the logging that should occur for a call to #execute(!)
       def log_execute(subcommand, *arguments)
         logger.debug do
-          "Executing #{subcommand.to_s} #{arguments} on #{description}"
+          "Executing #{subcommand} #{arguments.inspect} on #{description}"
         end
       end
   end

--- a/lib/derelict/instance.rb
+++ b/lib/derelict/instance.rb
@@ -7,6 +7,9 @@ module Derelict
     autoload :NonDirectory,  "derelict/instance/non_directory"
     autoload :NotFound,      "derelict/instance/not_found"
 
+    # Include "logger" method to get a logger for this class
+    include Logger
+
     # The default path to the Vagrant installation folder
     DEFAULT_PATH = "/Applications/Vagrant"
 
@@ -18,6 +21,7 @@ module Derelict
     #           defaults to DEFAULT_PATH)
     def initialize(path = DEFAULT_PATH)
       @path = path
+      logger.debug "Successfully initialized #{description}"
     end
 
     # Validates the data used for this instance
@@ -30,16 +34,22 @@ module Derelict
     #   * +Derelict::Instance::MissingBinary+ if the "vagrant" binary
     #     isn't in the expected location or is not executable
     def validate!
+      logger.debug "Starting validation for #{description}"
       raise NotFound.new path unless File.exists? path
       raise NonDirectory.new path unless File.directory? path
       raise MissingBinary.new vagrant unless File.exists? vagrant
       raise MissingBinary.new vagrant unless File.executable? vagrant
+      logger.info "Successfully validated #{description}"
       self
+    rescue Derelict::Instance::Invalid => e
+      logger.warn "Validation failed for #{description}: #{e.message}"
+      raise
     end
 
     # Determines the version of this Vagrant instance
     def version
       @version ||= (
+        logger.info "Determining Vagrant version for #{description}"
         output = execute!("--version").stdout
         Derelict::Parser::Version.new(output).version
       )
@@ -51,7 +61,9 @@ module Derelict
     #   * arguments:  Arguments to pass to the subcommand (optional)
     #   * block:      Passed through to Shell.execute (shell-executer)
     def execute(subcommand, *arguments, &block)
-      Shell.execute(command(subcommand, *arguments), &block)
+      command = command(subcommand, *arguments)
+      logger.debug "Executing #{command} using #{description}"
+      Shell.execute command, &block
     end
 
     # Executes a Vagrant subcommand, raising an exception on failure
@@ -65,7 +77,9 @@ module Derelict
       execute(subcommand, *arguments, &block).tap do |result|
         unless result.success?
           command = command(subcommand, *arguments)
-          raise CommandFailed.new command, result
+          exception = CommandFailed.new command
+          logger.warn "Command #{command} failed: #{exception.message}"
+          raise exception, result
         end
       end
     end
@@ -75,13 +89,23 @@ module Derelict
     #   * instance: The Derelict::Instance to use to control Vagrant
     #   * path:     The project path, which contains the Vagrantfile
     def connect(path)
+      logger.info "Creating connection for '#{path}' by #{description}"
       Derelict::Connection.new(self, path).validate!
+    end
+
+    # Provides a description of this Instance
+    #
+    # Mainly used for log messages.
+    def description
+      "Derelict::Instance at '#{path}'"
     end
 
     private
       # Retrieves the path to the vagrant binary for this instance
       def vagrant
-        File.join @path, "bin", "vagrant"
+        @vagrant ||= File.join(@path, "bin", "vagrant").tap do |vagrant|
+          logger.debug "Vagrant binary for #{description} is '#{vagrant}'"
+        end
       end
 
       # Constructs the command to execute a Vagrant subcommand
@@ -89,8 +113,13 @@ module Derelict
       #   * subcommand: Vagrant subcommand to run (:up, :status, etc.)
       #   * arguments:  Arguments to pass to the subcommand (optional)
       def command(subcommand, *arguments)
-        arguments = [vagrant, subcommand.to_s, arguments].flatten
-        arguments.map {|arg| Shellwords.escape arg }.join(' ')
+        args = [vagrant, subcommand.to_s, arguments].flatten
+        args.map {|a| Shellwords.escape a }.join(' ').tap do |command|
+          logger.debug [
+            "Generated command '#{command}' from subcommand ",
+            "'#{subcommand.to_s}' with arguments #{arguments.inspect}",
+          ].join
+        end
       end
   end
 end

--- a/lib/derelict/log4r.rb
+++ b/lib/derelict/log4r.rb
@@ -1,0 +1,5 @@
+module Derelict
+  module Log4r
+    autoload :ArrayOutputter, "derelict/log4r/array_outputter"
+  end
+end

--- a/lib/derelict/log4r/array_outputter.rb
+++ b/lib/derelict/log4r/array_outputter.rb
@@ -1,0 +1,39 @@
+require "log4r"
+
+module Derelict
+  module Log4r
+    # A Log4r Outputter which stores all logs in an array
+    #
+    # Logs are stored in the internal array by #write. Logs can be
+    # cleared using #flush, which returns the flushed logs too.
+    class ArrayOutputter < ::Log4r::Outputter
+      # Force the outputter to receive and store all levels of messages
+      def level
+        ::Log4r::ALL
+      end
+
+      # The internal array of messages
+      def messages
+        @messages ||= []
+      end
+
+      # Clear internal log messages array and return the erased data
+      def flush
+        messages.dup.tap { messages.clear }
+      end
+
+      private
+
+        # Write a message to the internal array
+        #
+        # This is an abstract method in the parent class, and handles
+        # persisting the log data. In this class, it saves the message
+        # into an internal array to be retrieved later.
+        #
+        #   * message: The log message to be persisted
+        def write(message)
+          messages << message
+        end
+    end
+  end
+end

--- a/lib/derelict/logger.rb
+++ b/lib/derelict/logger.rb
@@ -1,0 +1,19 @@
+module Derelict
+  # Provides a method to retrieve a logger
+  module Logger
+    # Retrieves the logger for this class
+    def logger
+      ::Log4r::Logger[logger_name] || ::Log4r::Logger.new(logger_name)
+    end
+
+    private
+      # Retrieves the name of the logger for this class
+      #
+      # By default, the name of the logger is just the lowercase
+      # version of the class name.
+      def logger_name
+        instance_name = self.respond_to?(:name) ? self.name : nil
+        (instance_name or self.class.name).downcase
+      end
+  end
+end

--- a/lib/derelict/logger.rb
+++ b/lib/derelict/logger.rb
@@ -12,8 +12,11 @@ module Derelict
       # By default, the name of the logger is just the lowercase
       # version of the class name.
       def logger_name
-        instance_name = self.respond_to?(:name) ? self.name : nil
-        (instance_name or self.class.name).downcase
+        if self.is_a? Module
+          self.name.downcase
+        else
+          self.class.name.downcase
+        end
       end
   end
 end

--- a/lib/derelict/parser.rb
+++ b/lib/derelict/parser.rb
@@ -4,11 +4,22 @@ module Derelict
     autoload :Status,  "derelict/parser/status"
     autoload :Version, "derelict/parser/version"
 
+    # Include "logger" method to get a logger for this class
+    include Logger
+
     attr_reader :output
 
     # Initializes the parser with the output it will be parsing
     def initialize(output)
       @output = output
+      logger.debug "Successfully initialized #{description}"
+    end
+
+    # Provides a description of this Parser
+    #
+    # Mainly used for log messages.
+    def description
+      "Derelict::Parser (unknown type)"
     end
   end
 end

--- a/lib/derelict/parser/status.rb
+++ b/lib/derelict/parser/status.rb
@@ -18,9 +18,9 @@ module Derelict
 
     # Retrieves the names of all virtual machines in the output
     #
-    # The names are returned as an array of symbols.
+    # The names are returned as a Set of symbols.
     def vm_names
-      states.keys
+      Set[*states.keys]
     end
 
     # Determines if a particular virtual machine exists in the output

--- a/lib/derelict/parser/status.rb
+++ b/lib/derelict/parser/status.rb
@@ -43,20 +43,34 @@ module Derelict
       states[vm_name.to_sym]
     end
 
+    # Provides a description of this Parser
+    #
+    # Mainly used for log messages.
+    def description
+      "Derelict::Parser::Status instance"
+    end
+
     private
       # Retrieves the virtual machine list section of the output
       def vm_lines
         @vm_lines ||= output.match(PARSE_LIST_FROM_OUTPUT).tap {|list|
+          logger.debug "Parsing VM list from output using #{description}"
           raise InvalidFormat.new "Couldn't find list of VMs" if list.nil?
         }.captures[0].lines
+      rescue Derelict::Parser::Status::InvalidFormat => e
+        logger.warn "List parsing failed for #{description}: #{e.message}"
+        raise
       end
 
       # Retrieves the state data for all virtual machines in the output
       #
       # The state is returned as a Hash, mapping virtual machine names
-      # (as symbols) to their state (also as a symbol).
+      # (as symbols) to their state (also as a symbol). Both of these
+      # symbols have spaces converted to underscores (for convenience
+      # when writing literals in other code).
       def states
         @states ||= (
+          logger.debug "Parsing states from VM list using #{description}"
           data = vm_lines.map {|l| l.match PARSE_STATE_FROM_LIST_ITEM }
           message = "Couldn't parse VM list"
           raise InvalidFormat.new message if data.any?(&:nil?)
@@ -65,6 +79,9 @@ module Derelict
             line.captures[1].gsub(/\s+/, "_").downcase.to_sym,
           ] }]
         )
+      rescue Derelict::Parser::Status::InvalidFormat => e
+        logger.warn "State parsing failed for #{description}: #{e.message}"
+        raise
       end
   end
 end

--- a/lib/derelict/parser/version.rb
+++ b/lib/derelict/parser/version.rb
@@ -9,10 +9,18 @@ module Derelict
     # Determines the version of Vagrant based on the output
     def version
       @version ||= (
+        logger.debug "Parsing version from output using #{description}"
         matches = output.match PARSE_VERSION_FROM_OUTPUT
         raise InvalidFormat.new output if matches.nil?
         matches.captures[0]
       )
+    end
+
+    # Provides a description of this Parser
+    #
+    # Mainly used for log messages.
+    def description
+      "Derelict::Parser::Version instance"
     end
   end
 end

--- a/spec/derelict/connection/invalid_spec.rb
+++ b/spec/derelict/connection/invalid_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Connection::Invalid do
   it "is autoloaded" do

--- a/spec/derelict/connection/not_found_spec.rb
+++ b/spec/derelict/connection/not_found_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Connection::NotFound do
   subject { Derelict::Connection::NotFound.new "/foo/bar" }

--- a/spec/derelict/connection_spec.rb
+++ b/spec/derelict/connection_spec.rb
@@ -1,25 +1,59 @@
 require "spec_helper"
 
 describe Derelict::Connection do
-  let(:instance) { double('instance') }
-  let(:path) { double('path') }
-  subject { Derelict::Connection.new instance, path }
+  let(:description) { "the test instance" }
+  let(:instance) { double("instance", :description => description) }
+  let(:path) { "/baz/qux" }
+  let(:connection) { Derelict::Connection.new instance, path }
+  subject { connection }
 
   it "is autoloaded" do
     should be_a Derelict::Connection
   end
 
+  include_context "logged messages"
+  let(:expected_logs) {[
+    "DEBUG connection: Successfully initialized Derelict::Connection at '/baz/qux' using the test instance\n"
+  ]}
+
   describe "#execute" do
+    let(:subcommand) { :test }
+    subject { connection.execute subcommand }
+
     it "should change current working directory first" do
-      expect(Dir).to receive(:chdir).with(path) # no yield
+      expect(Dir).to receive(:chdir).with(path).and_return(:foo) # no yield
       expect(instance).to_not receive(:execute)
-      subject.execute :test
+      expect(subject).to be :foo
     end
 
     it "should delegate to @instance#execute" do
       expect(Dir).to receive(:chdir).with(path).and_yield
-      expect(instance).to receive(:execute).with(:test)
-      subject.execute :test
+      expect(instance).to receive(:execute).with(:test).and_return(:bar)
+      expect(subject).to be :bar
     end
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG connection: Successfully initialized Derelict::Connection at '/baz/qux' using the test instance\n",
+      "DEBUG connection: Executing test [] on Derelict::Connection at '/baz/qux' using the test instance\n",
+    ]}
+  end
+
+  describe "#vm" do
+    let(:name) { :test }
+    let(:vm) { double("vm") }
+    before do
+      c = Derelict::VirtualMachine
+      expect(c).to receive(:new).with(connection, name).and_return(vm)
+      expect(vm).to receive(:validate!).and_return(vm)
+    end
+    subject { connection.vm name }
+    it { should be vm }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG connection: Successfully initialized Derelict::Connection at '/baz/qux' using the test instance\n",
+      "DEBUG connection: Retrieving VM 'test' from Derelict::Connection at '/baz/qux' using the test instance\n",
+    ]}
   end
 end

--- a/spec/derelict/connection_spec.rb
+++ b/spec/derelict/connection_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Connection do
   let(:instance) { double('instance') }

--- a/spec/derelict/exception_spec.rb
+++ b/spec/derelict/exception_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Exception do
   it "is autoloaded" do

--- a/spec/derelict/instance/command_failed_spec.rb
+++ b/spec/derelict/instance/command_failed_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Instance::CommandFailed do
   it "is autoloaded" do

--- a/spec/derelict/instance/invalid_spec.rb
+++ b/spec/derelict/instance/invalid_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Instance::Invalid do
   it "is autoloaded" do

--- a/spec/derelict/instance/missing_binary_spec.rb
+++ b/spec/derelict/instance/missing_binary_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Instance::MissingBinary do
   subject { Derelict::Instance::MissingBinary.new "/foo/bar" }

--- a/spec/derelict/instance/non_directory_spec.rb
+++ b/spec/derelict/instance/non_directory_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Instance::NonDirectory do
   subject { Derelict::Instance::NonDirectory.new "/foo/bar" }

--- a/spec/derelict/instance/not_found_spec.rb
+++ b/spec/derelict/instance/not_found_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Instance::NotFound do
   subject { Derelict::Instance::NotFound.new "/foo/bar" }

--- a/spec/derelict/instance_spec.rb
+++ b/spec/derelict/instance_spec.rb
@@ -50,6 +50,14 @@ describe Derelict::Instance do
         it "should be chainable" do
           expect(subject).to be_a Derelict::Instance
         end
+
+        include_context "logged messages"
+        let(:expected_logs) {[
+          "DEBUG instance: Successfully initialized Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Starting validation for Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Vagrant binary for Derelict::Instance at '/foo/bar' is '/foo/bar/bin/vagrant'\n",
+          " INFO instance: Successfully validated Derelict::Instance at '/foo/bar'\n",
+        ]}
       end
 
       context "with non-existent path" do
@@ -60,6 +68,13 @@ describe Derelict::Instance do
         it "should raise NotFound" do
           expect { subject }.to raise_error Derelict::Instance::NotFound
         end
+
+        include_context "logged messages"
+        let(:expected_logs) {[
+          "DEBUG instance: Successfully initialized Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Starting validation for Derelict::Instance at '/foo/bar'\n",
+          " WARN instance: Validation failed for Derelict::Instance at '/foo/bar': Invalid Derelict instance: directory doesn't exist: /foo/bar\n",
+        ]}
       end
 
       context "with path pointing to a file" do
@@ -71,6 +86,13 @@ describe Derelict::Instance do
         it "should raise NonDirectory" do
           expect { subject }.to raise_error Derelict::Instance::NonDirectory
         end
+
+        include_context "logged messages"
+        let(:expected_logs) {[
+          "DEBUG instance: Successfully initialized Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Starting validation for Derelict::Instance at '/foo/bar'\n",
+          " WARN instance: Validation failed for Derelict::Instance at '/foo/bar': Invalid Derelict instance: expected directory, found file: /foo/bar\n",
+        ]}
       end
 
       context "with vagrant binary missing" do
@@ -83,6 +105,14 @@ describe Derelict::Instance do
         it "should raise MissingBinary" do
           expect { subject }.to raise_error Derelict::Instance::MissingBinary
         end
+
+        include_context "logged messages"
+        let(:expected_logs) {[
+          "DEBUG instance: Successfully initialized Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Starting validation for Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Vagrant binary for Derelict::Instance at '/foo/bar' is '/foo/bar/bin/vagrant'\n",
+          " WARN instance: Validation failed for Derelict::Instance at '/foo/bar': Invalid Derelict instance: 'vagrant' binary not found at /foo/bar/bin/vagrant\n",
+        ]}
       end
 
       context "with vagrant binary non-executable" do
@@ -96,6 +126,14 @@ describe Derelict::Instance do
         it "should raise MissingBinary" do
           expect { subject }.to raise_error Derelict::Instance::MissingBinary
         end
+
+        include_context "logged messages"
+        let(:expected_logs) {[
+          "DEBUG instance: Successfully initialized Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Starting validation for Derelict::Instance at '/foo/bar'\n",
+          "DEBUG instance: Vagrant binary for Derelict::Instance at '/foo/bar' is '/foo/bar/bin/vagrant'\n",
+          " WARN instance: Validation failed for Derelict::Instance at '/foo/bar': Invalid Derelict instance: 'vagrant' binary not found at /foo/bar/bin/vagrant\n",
+        ]}
       end
     end
 
@@ -118,6 +156,14 @@ describe Derelict::Instance do
       its(:stdout) { should eq "stdout\n" }
       its(:stderr) { should eq "stderr\n" }
       its(:success?) { should be true }
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG instance: Successfully initialized Derelict::Instance at '/foo/bar'\n",
+        "DEBUG instance: Vagrant binary for Derelict::Instance at '/foo/bar' is '/foo/bar/bin/vagrant'\n",
+        "DEBUG instance: Generated command '/foo/bar/bin/vagrant test arg\\ 1' from subcommand 'test' with arguments [\"arg 1\"]\n",
+        "DEBUG instance: Executing /foo/bar/bin/vagrant test arg\\ 1 using Derelict::Instance at '/foo/bar'\n",
+      ]}
     end
   end
 end

--- a/spec/derelict/instance_spec.rb
+++ b/spec/derelict/instance_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Instance do
   let(:instance) { Derelict::Instance.new path }

--- a/spec/derelict/log4r/array_outputter_spec.rb
+++ b/spec/derelict/log4r/array_outputter_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe Derelict::Log4r::ArrayOutputter do
+  let(:logger) { Log4r::Logger.new "test::array_outputter_spec" }
+  let(:outputter) { Derelict::Log4r::ArrayOutputter.new "test" }
+  before { logger.outputters = [outputter] }
+  subject { outputter }
+
+  describe "#level" do
+    subject { outputter.level }
+    it { should be Log4r::ALL }
+  end
+
+  context "with no data" do
+    describe "#messages" do
+      subject { outputter.messages }
+      it { should eq [] }
+    end
+
+    describe "#flush" do
+      subject { outputter.flush }
+      it { should eq [] }
+    end
+  end
+
+  context "after INFO level log" do
+    before { logger.info "test info message" }
+    let(:message) { " INFO array_outputter_spec: test info message\n" }
+
+    describe "#messages" do
+      subject { outputter.messages }
+      it { should eq [message] }
+    end
+
+    context "then #flush" do
+      subject { outputter.flush }
+      it { should eq [message] }
+    end
+  end
+end

--- a/spec/derelict/parser/status/invalid_format_spec.rb
+++ b/spec/derelict/parser/status/invalid_format_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Parser::Status::InvalidFormat do
   it "is autoloaded" do

--- a/spec/derelict/parser/status_spec.rb
+++ b/spec/derelict/parser/status_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Parser::Status do
   subject { Derelict::Parser::Status.new output }

--- a/spec/derelict/parser/status_spec.rb
+++ b/spec/derelict/parser/status_spec.rb
@@ -24,7 +24,7 @@ describe Derelict::Parser::Status do
 
     describe "#vm_names" do
       subject { Derelict::Parser::Status.new(output).vm_names }
-      it { should eq [:foo] }
+      it { should eq Set[:foo] }
 
       include_context "logged messages"
       let(:expected_logs) {[
@@ -82,7 +82,7 @@ describe Derelict::Parser::Status do
 
     describe "#vm_names" do
       subject { Derelict::Parser::Status.new(output).vm_names }
-      it { should eq [:foo, :bar] }
+      it { should eq Set[:foo, :bar] }
 
       include_context "logged messages"
       let(:expected_logs) {[

--- a/spec/derelict/parser/status_spec.rb
+++ b/spec/derelict/parser/status_spec.rb
@@ -25,6 +25,13 @@ describe Derelict::Parser::Status do
     describe "#vm_names" do
       subject { Derelict::Parser::Status.new(output).vm_names }
       it { should eq [:foo] }
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing states from VM list using Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing VM list from output using Derelict::Parser::Status instance\n",
+      ]}
     end
 
     describe "#exists?" do
@@ -35,6 +42,11 @@ describe Derelict::Parser::Status do
       it "should return false for unknown VM" do
         expect(subject.exists?(:bar)).to be false
       end
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+      ]}
     end
 
     describe "#state" do
@@ -46,6 +58,11 @@ describe Derelict::Parser::Status do
         type = Derelict::VirtualMachine::NotFound
         expect { subject.state(:bar) }.to raise_error type
       end
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+      ]}
     end
   end
 
@@ -66,6 +83,13 @@ describe Derelict::Parser::Status do
     describe "#vm_names" do
       subject { Derelict::Parser::Status.new(output).vm_names }
       it { should eq [:foo, :bar] }
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing states from VM list using Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing VM list from output using Derelict::Parser::Status instance\n",
+      ]}
     end
 
     describe "#exists?" do
@@ -80,6 +104,11 @@ describe Derelict::Parser::Status do
       it "should return false for unknown VM" do
         expect(subject.exists?(:baz)).to be false
       end
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+      ]}
     end
 
     describe "#state" do
@@ -95,6 +124,11 @@ describe Derelict::Parser::Status do
         type = Derelict::VirtualMachine::NotFound
         expect { subject.state(:baz) }.to raise_error type
       end
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+      ]}
     end
   end
 
@@ -116,6 +150,15 @@ describe Derelict::Parser::Status do
         ].join
         expect { subject }.to raise_error type, message
       end
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing states from VM list using Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing VM list from output using Derelict::Parser::Status instance\n",
+        " WARN status: List parsing failed for Derelict::Parser::Status instance: Output from 'vagrant status' was in an unexpected format: Couldn't find list of VMs\n",
+        " WARN status: State parsing failed for Derelict::Parser::Status instance: Output from 'vagrant status' was in an unexpected format: Couldn't find list of VMs\n",
+      ]}
     end
 
     describe "#state" do
@@ -128,6 +171,15 @@ describe Derelict::Parser::Status do
         ].join
         expect { subject }.to raise_error type, message
       end
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG status: Successfully initialized Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing states from VM list using Derelict::Parser::Status instance\n",
+        "DEBUG status: Parsing VM list from output using Derelict::Parser::Status instance\n",
+        " WARN status: List parsing failed for Derelict::Parser::Status instance: Output from 'vagrant status' was in an unexpected format: Couldn't find list of VMs\n",
+        " WARN status: State parsing failed for Derelict::Parser::Status instance: Output from 'vagrant status' was in an unexpected format: Couldn't find list of VMs\n",
+      ]}
     end
   end
 

--- a/spec/derelict/parser/version/invalid_format_spec.rb
+++ b/spec/derelict/parser/version/invalid_format_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Parser::Version::InvalidFormat do
   it "is autoloaded" do

--- a/spec/derelict/parser/version_spec.rb
+++ b/spec/derelict/parser/version_spec.rb
@@ -9,11 +9,23 @@ describe Derelict::Parser::Version do
     context "on Vagrant 1.0.7" do
       let(:stdout) { "Vagrant version 1.0.7\n" }
       it { should eq "1.0.7" }
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG version: Successfully initialized Derelict::Parser::Version instance\n",
+        "DEBUG version: Parsing version from output using Derelict::Parser::Version instance\n",
+      ]}
     end
 
     context "on Vagrant 1.3.4" do
       let(:stdout) { "Vagrant v1.3.4\n" }
       it { should eq "1.3.4" }
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG version: Successfully initialized Derelict::Parser::Version instance\n",
+        "DEBUG version: Parsing version from output using Derelict::Parser::Version instance\n",
+      ]}
     end
   end
 end

--- a/spec/derelict/parser/version_spec.rb
+++ b/spec/derelict/parser/version_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Parser::Version do
   let(:parser) { Derelict::Parser::Version.new stdout }

--- a/spec/derelict/parser_spec.rb
+++ b/spec/derelict/parser_spec.rb
@@ -10,9 +10,15 @@ describe Derelict::Parser do
 
   describe "#initialize" do
     let(:output) { "the output" }
+    let(:description) { "test parser" }
 
     it "should store output" do
       expect(subject.output).to eq "the output"
     end
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG parser: Successfully initialized Derelict::Parser (unknown type)\n",
+    ]}
   end
 end

--- a/spec/derelict/parser_spec.rb
+++ b/spec/derelict/parser_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::Parser do
   let(:output) { nil }

--- a/spec/derelict/virtual_machine/invalid_spec.rb
+++ b/spec/derelict/virtual_machine/invalid_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::VirtualMachine::Invalid do
   it "is autoloaded" do

--- a/spec/derelict/virtual_machine/not_found_spec.rb
+++ b/spec/derelict/virtual_machine/not_found_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::VirtualMachine::NotFound do
   let(:connection) { double("connection") }

--- a/spec/derelict/virtual_machine_spec.rb
+++ b/spec/derelict/virtual_machine_spec.rb
@@ -1,4 +1,4 @@
-require "derelict"
+require "spec_helper"
 
 describe Derelict::VirtualMachine do
   let(:connection) { double("connection") }

--- a/spec/derelict_spec.rb
+++ b/spec/derelict_spec.rb
@@ -1,11 +1,19 @@
 require "spec_helper"
 
 describe Derelict do
-  let(:logger) { Derelict.logger }
+  describe "#instance" do
+    let(:instance) { double("instance") }
+    before {
+      expect(Derelict::Instance).to receive(:new).and_return(instance)
+      expect(instance).to receive(:validate!).and_return(instance)
+    }
 
-  describe "::logger" do
-    subject { logger }
-    it { should be_a Log4r::Logger }
-    its(:name) { should eq "derelict" }
+    subject { Derelict.instance }
+    it { should be instance }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      " INFO derelict: Creating and validating new instance for '/Applications/Vagrant'\n"
+    ]}
   end
 end

--- a/spec/derelict_spec.rb
+++ b/spec/derelict_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+describe Derelict do
+  let(:logger) { Derelict.logger }
+
+  describe "::logger" do
+    subject { logger }
+    it { should be_a Log4r::Logger }
+    its(:name) { should eq "derelict" }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,4 +14,9 @@ RSpec.configure do |config|
     # Add the ArrayOutputter to the base Derelict logger
     derelict_logger.outputters = [array_outputter]
   end
+
+  # Forbid .should syntax
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,17 @@
+require "derelict"
+
+derelict_logger = Derelict.logger
+array_outputter = Derelict::Log4r::ArrayOutputter.new "rspec"
+
+RSpec.configure do |config|
+  config.before :each do
+    # Start each spec with an empty ArrayOutputter
+    array_outputter.flush
+
+    # Remove any outputters set on other loggers
+    Log4r::Logger.each {|fullname, logger| logger.outputters = [] }
+
+    # Add the ArrayOutputter to the base Derelict logger
+    derelict_logger.outputters = [array_outputter]
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "derelict"
+require File.join(File.dirname(__FILE__), "support", "log_context")
 
 derelict_logger = Derelict.logger
 array_outputter = Derelict::Log4r::ArrayOutputter.new "rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,4 +19,10 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = "random"
 end

--- a/spec/support/log_context.rb
+++ b/spec/support/log_context.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+# Provides set-up and examples to assert logged messages
+#
+# Usage:
+#
+#   * Ensure that the "subject" from the parent context will perform
+#     the action which is expected to produce the log messages
+#   * Provide a "let(:expected_logs)" block, defining which logs are
+#     expected to result from the action performed in the "before"
+#     block (otherwise, it defaults to expecting no log messages)
+shared_context "logged messages" do
+  let(:outputter) { Log4r::Outputter["rspec"] }
+  let(:messages) { outputter.messages }
+
+  # Override this let block when including this shared context
+  let(:expected_logs) { [] }
+
+  # Add an additional context for readability in the output
+  describe "logged messages" do
+    before do
+      begin
+        subject
+      rescue Exception
+      end
+    end
+
+    it "should be an Array" do
+      expect(messages).to be_an Array
+    end
+
+    it "should contain the expected log messages" do
+      expect(messages).to eq expected_logs
+    end
+  end
+end


### PR DESCRIPTION
- Uses Log4r
- Adds a `Derelict::Logging` mixin to provide a `logger` method on instances of most classes
- Fully tested, using a test helper and an `ArrayOutputter` to manage expectations of logged messages
- Adds a `debug!` class method on `Derelict` to enable debug mode (i.e., print internal logging to stdout)

Fixes #7.
