### PR TITLE
Add plugin manipulation commands

### DIFF
--- a/derelict.gemspec
+++ b/derelict.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "log4r"
   spec.add_runtime_dependency "memoist"
   spec.add_runtime_dependency "shell-executer"
+  spec.add_runtime_dependency "mime-types", "<2.0" # for coveralls 1.8
 
 
   version_major = RbConfig::CONFIG["MAJOR"].to_i

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -13,6 +13,7 @@ module Derelict
   autoload :Exception,      "derelict/exception"
   autoload :Instance,       "derelict/instance"
   autoload :Parser,         "derelict/parser"
+  autoload :Plugin,         "derelict/plugin"
   autoload :Utils,          "derelict/utils"
   autoload :VirtualMachine, "derelict/virtual_machine"
 

--- a/lib/derelict/instance.rb
+++ b/lib/derelict/instance.rb
@@ -92,6 +92,12 @@ module Derelict
       Derelict::Connection.new(self, path).validate!
     end
 
+    # Initializes a plugin manager for use with this instance
+    def plugins
+      logger.info "Creating plugin manager for #{description}"
+      Derelict::Plugin::Manager.new(self)
+    end
+
     # Provides a description of this Instance
     #
     # Mainly used for log messages.

--- a/lib/derelict/parser.rb
+++ b/lib/derelict/parser.rb
@@ -1,8 +1,9 @@
 module Derelict
   # Base class for parsers, which extract data from command output
   class Parser
-    autoload :Status,  "derelict/parser/status"
-    autoload :Version, "derelict/parser/version"
+    autoload :PluginList, "derelict/parser/plugin_list"
+    autoload :Status,     "derelict/parser/status"
+    autoload :Version,    "derelict/parser/version"
 
     # Include "logger" method to get a logger for this class
     include Utils::Logger

--- a/lib/derelict/parser/plugin_list.rb
+++ b/lib/derelict/parser/plugin_list.rb
@@ -1,0 +1,47 @@
+module Derelict
+  # Parses the output of "vagrant plugin list"
+  class Parser::PluginList < Parser
+    autoload :InvalidFormat, "derelict/parser/plugin_list/invalid_format"
+
+    # Include "memoize" class method to memoize methods
+    extend Memoist
+
+    # Regexp to parse a plugin line into a plugin name and version
+    #
+    # Capture groups:
+    #
+    #   1. Plugin name, as listed in the output
+    #   2. Currently installed version (without surrounding brackets)
+    PARSE_PLUGIN = %r[
+      ^(.*)            # Plugin name starts at the start of the line.
+      \                # Version is separated by a space character,
+      \(([0-9\-_.]+)\) # contains version string surrounded by brackets
+      $                # at the end of the line.
+    ]x                 # Ignore whitespace to allow these comments.
+
+    # Retrieves a Set containing all the plugins from the output
+    def plugins
+      plugin_lines.map {|l| parse_line l.match(PARSE_PLUGIN) }.to_set
+    end
+
+    # Provides a description of this Parser
+    #
+    # Mainly used for log messages.
+    def description
+      "Derelict::Parser::PluginList instance"
+    end
+
+    private
+      # Retrieves an array of the plugin lines in the output
+      def plugin_lines
+        return [] if output.match /no plugins installed/i
+        output.lines
+      end
+
+      # Parses a single line of the output into a Plugin object
+      def parse_line(match)
+        raise InvalidFormat.new "Couldn't parse plugin" if match.nil?
+        Derelict::Plugin.new *match.captures[0..1]
+      end
+  end
+end

--- a/lib/derelict/parser/plugin_list/invalid_format.rb
+++ b/lib/derelict/parser/plugin_list/invalid_format.rb
@@ -1,0 +1,16 @@
+module Derelict
+  class Parser
+    class PluginList
+      # The plugin list wasn't in the expected format, can't be parsed
+      class InvalidFormat < Derelict::Exception
+        include Derelict::Exception::OptionalReason
+
+        private
+          # Retrieves the default error message
+          def default_message
+            "Output from 'vagrant plugin list' was in an unexpected format"
+          end
+      end
+    end
+  end
+end

--- a/lib/derelict/plugin.rb
+++ b/lib/derelict/plugin.rb
@@ -1,7 +1,8 @@
 module Derelict
   # Represents an individual Vagrant plugin at a particular version
   class Plugin
-    autoload :Manager, "derelict/plugin/manager"
+    autoload :Manager,  "derelict/plugin/manager"
+    autoload :NotFound, "derelict/plugin/not_found"
 
     attr_reader :name, :version
 

--- a/lib/derelict/plugin.rb
+++ b/lib/derelict/plugin.rb
@@ -1,6 +1,8 @@
 module Derelict
   # Represents an individual Vagrant plugin at a particular version
   class Plugin
+    autoload :Manager, "derelict/plugin/manager"
+
     attr_reader :name, :version
 
     # Initializes a plugin with a particular name and version

--- a/lib/derelict/plugin.rb
+++ b/lib/derelict/plugin.rb
@@ -11,5 +11,16 @@ module Derelict
       @name = name
       @version = version
     end
+
+    # Ensure equivalent Plugins are equal to this one
+    def ==(other)
+      other.name == name and other.version == version
+    end
+    alias_method :eql?, :==
+
+    # Make equivalent Plugins hash to the same value
+    def hash
+      name.hash ^ version.hash
+    end
   end
 end

--- a/lib/derelict/plugin.rb
+++ b/lib/derelict/plugin.rb
@@ -1,0 +1,15 @@
+module Derelict
+  # Represents an individual Vagrant plugin at a particular version
+  class Plugin
+    attr_reader :name, :version
+
+    # Initializes a plugin with a particular name and version
+    #
+    #   * name:    The name of the plugin represented by this object
+    #   * version: The version of the plugin represented by this object
+    def initialize(name, version)
+      @name = name
+      @version = version
+    end
+  end
+end

--- a/lib/derelict/plugin/manager.rb
+++ b/lib/derelict/plugin/manager.rb
@@ -1,0 +1,27 @@
+module Derelict
+  class Plugin
+    # A class that handles managing plugins for a Vagrant instance
+    class Manager
+      # Include "logger" method to get a logger for this class
+      include Utils::Logger
+
+      attr_reader :instance
+
+      # Initializes a Manager for use with a particular instance
+      #
+      #   * instance: The Derelict::Instance which will have its
+      #               plugins managed by this Manager
+      def initialize(instance)
+        @instance = instance
+        logger.debug "Successfully initialized #{description}"
+      end
+
+      # Provides a description of this Connection
+      #
+      # Mainly used for log messages.
+      def description
+        "Derelict::Plugin::Manager for #{instance.description}"
+      end
+    end
+  end
+end

--- a/lib/derelict/plugin/manager.rb
+++ b/lib/derelict/plugin/manager.rb
@@ -21,6 +21,7 @@ module Derelict
 
       # Retrieves the Set of currently installed plugins
       def list
+        logger.info "Retrieving Vagrant plugin list for #{description}"
         output = instance.execute!(:plugin, "list").stdout
         Derelict::Parser::PluginList.new(output).plugins
       end
@@ -33,6 +34,37 @@ module Derelict
         fetch plugin_name; true
       rescue Plugin::NotFound
         false
+      end
+
+      # Installs a plugin (optionally a particular version)
+      #
+      # If no version is specified, the latest stable version is used
+      # by Vagrant.
+      #
+      #   * plugin_name: Name of the plugin to install (as a string)
+      #   * version:     Particular version to install (optional,
+      #                  latest version will be installed if omitted)
+      def install(plugin_name, version = nil)
+        logger.info "Installing plugin '#{plugin_name}' using #{description}"
+        command = [:plugin, "install", plugin_name]
+        command.concat ["--plugin-version", version] unless version.nil?
+        instance.execute! *command
+      end
+
+      # Uninstalls a particular Vagrant plugin
+      #
+      #   * plugin_name: Name of the plugin to uninstall (as a string)
+      def uninstall(plugin_name)
+        logger.info "Uninstalling plugin '#{plugin_name}' using #{description}"
+        instance.execute! :plugin, "uninstall", plugin_name
+      end
+
+      # Updates a particular Vagrant plugin
+      #
+      #   * plugin_name: Name of the plugin to update (as a string)
+      def update(plugin_name)
+        logger.info "Updating plugin '#{plugin_name}' using #{description}"
+        instance.execute! :plugin, "update", plugin_name
       end
 
       # Retrieves a plugin with a particular name

--- a/lib/derelict/plugin/manager.rb
+++ b/lib/derelict/plugin/manager.rb
@@ -2,6 +2,9 @@ module Derelict
   class Plugin
     # A class that handles managing plugins for a Vagrant instance
     class Manager
+      # Include "memoize" class method to memoize methods
+      extend Memoist
+
       # Include "logger" method to get a logger for this class
       include Utils::Logger
 
@@ -15,6 +18,13 @@ module Derelict
         @instance = instance
         logger.debug "Successfully initialized #{description}"
       end
+
+      # Retrieves the Set of currently installed plugins
+      def list
+        output = instance.execute!(:plugin, "list").stdout
+        Derelict::Parser::PluginList.new(output).plugins
+      end
+      memoize :list
 
       # Provides a description of this Connection
       #

--- a/lib/derelict/plugin/manager.rb
+++ b/lib/derelict/plugin/manager.rb
@@ -26,6 +26,24 @@ module Derelict
       end
       memoize :list
 
+      # Determines whether a particular plugin is installed
+      #
+      #   * plugin_name: Name of the plugin to look for (as a string)
+      def installed?(plugin_name)
+        fetch plugin_name; true
+      rescue Plugin::NotFound
+        false
+      end
+
+      # Retrieves a plugin with a particular name
+      #
+      #   * plugin_name: Name of the plugin to look for (as a string)
+      def fetch(plugin_name)
+        list.find {|plugin| plugin.name == plugin_name}.tap do |plugin|
+          raise Plugin::NotFound.new plugin_name if plugin.nil?
+        end
+      end
+
       # Provides a description of this Connection
       #
       # Mainly used for log messages.

--- a/lib/derelict/plugin/not_found.rb
+++ b/lib/derelict/plugin/not_found.rb
@@ -1,0 +1,14 @@
+module Derelict
+  class Plugin
+    # A plugin that isn't currently installed has been retrieved
+    class NotFound < Derelict::Exception
+      # Initializes a new instance of this exception, for a plugin name
+      #
+      #   * plugin_name: The name of the plugin that this exception
+      #                  relates to
+      def initialize(plugin_name)
+        super "Plugin '#{plugin_name}' is not currently installed"
+      end
+    end
+  end
+end

--- a/spec/derelict/instance_spec.rb
+++ b/spec/derelict/instance_spec.rb
@@ -25,6 +25,12 @@ describe Derelict::Instance do
     end
   end
 
+  describe "#plugins" do
+    subject { instance.plugins }
+    it { should be_a Derelict::Plugin::Manager }
+    its(:instance) { should be instance }
+  end
+
   context "with path parameter" do
     let(:path) { "/foo/bar" }
 

--- a/spec/derelict/parser/plugin_list/invalid_format_spec.rb
+++ b/spec/derelict/parser/plugin_list/invalid_format_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Derelict::Parser::PluginList::InvalidFormat do
+  it "is autoloaded" do
+    should be_a Derelict::Parser::PluginList::InvalidFormat
+  end
+
+  context "when using default reason" do
+    its(:message) { should eq "Output from 'vagrant plugin list' was in an unexpected format" }
+  end
+
+  context "when using custom reason" do
+    subject { Derelict::Parser::PluginList::InvalidFormat.new "reason" }
+    its(:message) { should eq "Output from 'vagrant plugin list' was in an unexpected format: reason" }
+  end
+end

--- a/spec/derelict/parser/plugin_list_spec.rb
+++ b/spec/derelict/parser/plugin_list_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe Derelict::Parser::PluginList do
+  subject { Derelict::Parser::PluginList.new output }
+  let(:output) { nil }
+
+  it "is autoloaded" do
+    should be_a Derelict::Parser::PluginList
+  end
+
+  context "with valid output" do
+    let(:output) {
+      <<-END.gsub /^ +/, ""
+        foo (2.3.4)
+        bar (1.2.3)
+      END
+    }
+
+    describe "#plugins" do
+      subject { Derelict::Parser::PluginList.new(output).plugins }
+      let(:foo) { Derelict::Plugin.new "foo", "2.3.4" }
+      let(:bar) { Derelict::Plugin.new "bar", "1.2.3" }
+      it { should eq Set[foo, bar] }
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG pluginlist: Successfully initialized Derelict::Parser::PluginList instance\n",
+      ]}
+    end
+  end
+end

--- a/spec/derelict/plugin/manager_spec.rb
+++ b/spec/derelict/plugin/manager_spec.rb
@@ -29,4 +29,42 @@ describe Derelict::Plugin::Manager do
 
     it { should be plugins }
   end
+
+  describe "#fetch" do
+    let(:foo) { double("foo", :name => "foo") }
+    let(:bar) { double("bar", :name => "bar") }
+    let(:plugins) { [foo, bar] }
+
+    let(:plugin_name) { double("plugin_name") }
+    subject { manager.fetch plugin_name }
+    before { expect(manager).to receive(:list).and_return(plugins) }
+
+    context "with known plugin" do
+      let(:plugin_name) { "foo" }
+      it { should be foo }
+    end
+
+    context "with unknown plugin" do
+      let(:plugin_name) { "qux" }
+      it "should raise NotFound" do
+        expect { subject }.to raise_error Derelict::Plugin::NotFound
+      end
+    end
+  end
+
+  describe "#installed?" do
+    let(:plugin_name) { double("plugin_name") }
+    let(:result) { double("result") }
+    subject { manager.installed? plugin_name }
+
+    context "with known plugin" do
+      before { expect(manager).to receive(:fetch).with(plugin_name).and_return(result) }
+      it { should be true }
+    end
+
+    context "with unknown plugin" do
+      before { expect(manager).to receive(:fetch).with(plugin_name).and_raise(Derelict::Plugin::NotFound.new plugin_name) }
+      it { should be false }
+    end
+  end
 end

--- a/spec/derelict/plugin/manager_spec.rb
+++ b/spec/derelict/plugin/manager_spec.rb
@@ -28,7 +28,91 @@ describe Derelict::Plugin::Manager do
     end
 
     it { should be plugins }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+      " INFO manager: Retrieving Vagrant plugin list for Derelict::Plugin::Manager for test instance\n",
+    ]}
   end
+
+  describe "#installed?" do
+    let(:plugin_name) { double("plugin_name") }
+    let(:result) { double("result") }
+    subject { manager.installed? plugin_name }
+
+    context "with known plugin" do
+      before { expect(manager).to receive(:fetch).with(plugin_name).and_return(result) }
+      it { should be true }
+    end
+
+    context "with unknown plugin" do
+      before { expect(manager).to receive(:fetch).with(plugin_name).and_raise(Derelict::Plugin::NotFound.new plugin_name) }
+      it { should be false }
+    end
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+      " INFO manager: Retrieving Vagrant plugin list for Derelict::Plugin::Manager for test instance\n",
+    ]}
+  end
+
+  describe "#install" do
+    let(:plugin_name) { double("plugin_name", :to_s => "test plugin") }
+    let(:version) { double("version") }
+    let(:result) { double("result") }
+    subject { manager.install plugin_name, version }
+
+    before do
+      expect(instance).to receive(:execute!).with(:plugin, "install", plugin_name, '--plugin-version', version).and_return(result)
+    end
+
+    it { should be result }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+      " INFO manager: Installing plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+    ]}
+  end
+
+  describe "#uninstall" do
+    let(:plugin_name) { double("plugin_name", :to_s => "test plugin") }
+    let(:result) { double("result") }
+    subject { manager.uninstall plugin_name }
+
+    before do
+      expect(instance).to receive(:execute!).with(:plugin, "uninstall", plugin_name).and_return(result)
+    end
+
+    it { should be result }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+      " INFO manager: Uninstalling plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+    ]}
+  end
+
+  describe "#update" do
+    let(:plugin_name) { double("plugin_name", :to_s => "test plugin") }
+    let(:result) { double("result") }
+    subject { manager.update plugin_name }
+
+    before do
+      expect(instance).to receive(:execute!).with(:plugin, "update", plugin_name).and_return(result)
+    end
+
+    it { should be result }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+      " INFO manager: Updating plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+    ]}
+  end
+
 
   describe "#fetch" do
     let(:foo) { double("foo", :name => "foo") }
@@ -50,21 +134,11 @@ describe Derelict::Plugin::Manager do
         expect { subject }.to raise_error Derelict::Plugin::NotFound
       end
     end
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+    ]}
   end
 
-  describe "#installed?" do
-    let(:plugin_name) { double("plugin_name") }
-    let(:result) { double("result") }
-    subject { manager.installed? plugin_name }
-
-    context "with known plugin" do
-      before { expect(manager).to receive(:fetch).with(plugin_name).and_return(result) }
-      it { should be true }
-    end
-
-    context "with unknown plugin" do
-      before { expect(manager).to receive(:fetch).with(plugin_name).and_raise(Derelict::Plugin::NotFound.new plugin_name) }
-      it { should be false }
-    end
-  end
 end

--- a/spec/derelict/plugin/manager_spec.rb
+++ b/spec/derelict/plugin/manager_spec.rb
@@ -59,58 +59,97 @@ describe Derelict::Plugin::Manager do
   end
 
   describe "#install" do
+    let(:log) { true }
     let(:plugin_name) { double("plugin_name", :to_s => "test plugin") }
     let(:version) { double("version") }
     let(:result) { double("result") }
-    subject { manager.install plugin_name, version }
+    subject { manager.install plugin_name, :version => version, :log => log }
 
     before do
-      expect(instance).to receive(:execute!).with(:plugin, "install", plugin_name, '--plugin-version', version).and_return(result)
+      expect(instance).to receive(:execute!).with(:plugin, "install", plugin_name, '--plugin-version', version).and_yield("test").and_return(result)
     end
 
     it { should be result }
 
-    include_context "logged messages"
-    let(:expected_logs) {[
-      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
-      " INFO manager: Installing plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
-    ]}
+    context "with logging enabled" do
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+        " INFO manager: Installing plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+        " INFO external: test\n",
+      ]}
+    end
+
+    context "with logging disabled" do
+      let(:log) { false }
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+        " INFO manager: Installing plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+      ]}
+    end
   end
 
   describe "#uninstall" do
+    let(:log) { true }
     let(:plugin_name) { double("plugin_name", :to_s => "test plugin") }
     let(:result) { double("result") }
-    subject { manager.uninstall plugin_name }
+    subject { manager.uninstall plugin_name, :log => log }
 
     before do
-      expect(instance).to receive(:execute!).with(:plugin, "uninstall", plugin_name).and_return(result)
+      expect(instance).to receive(:execute!).with(:plugin, "uninstall", plugin_name).and_yield("test").and_return(result)
     end
 
     it { should be result }
 
-    include_context "logged messages"
-    let(:expected_logs) {[
-      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
-      " INFO manager: Uninstalling plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
-    ]}
+    context "with logging enabled" do
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+        " INFO manager: Uninstalling plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+        " INFO external: test\n",
+      ]}
+    end
+
+    context "with logging disabled" do
+      let(:log) { false }
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+        " INFO manager: Uninstalling plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+      ]}
+    end
   end
 
   describe "#update" do
+    let(:log) { true }
     let(:plugin_name) { double("plugin_name", :to_s => "test plugin") }
     let(:result) { double("result") }
-    subject { manager.update plugin_name }
+    subject { manager.update plugin_name, :log => log }
 
     before do
-      expect(instance).to receive(:execute!).with(:plugin, "update", plugin_name).and_return(result)
+      expect(instance).to receive(:execute!).with(:plugin, "update", plugin_name).and_yield("test").and_return(result)
     end
 
     it { should be result }
 
-    include_context "logged messages"
-    let(:expected_logs) {[
-      "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
-      " INFO manager: Updating plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
-    ]}
+    context "with logging enabled" do
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+        " INFO manager: Updating plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+        " INFO external: test\n",
+      ]}
+    end
+
+    context "with logging disabled" do
+      let(:log) { false }
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n",
+        " INFO manager: Updating plugin 'test plugin' using Derelict::Plugin::Manager for test instance\n",
+      ]}
+    end
   end
 
 

--- a/spec/derelict/plugin/manager_spec.rb
+++ b/spec/derelict/plugin/manager_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Derelict::Plugin::Manager do
+  let(:instance) { double("instance", :description => "test instance") }
+  let(:manager) { Derelict::Plugin::Manager.new instance }
+  subject { manager }
+
+  it "is autoloaded" do
+    should be_a Derelict::Plugin::Manager
+  end
+
+  include_context "logged messages"
+  let(:expected_logs) {[
+    "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n"
+  ]}
+end

--- a/spec/derelict/plugin/manager_spec.rb
+++ b/spec/derelict/plugin/manager_spec.rb
@@ -13,4 +13,20 @@ describe Derelict::Plugin::Manager do
   let(:expected_logs) {[
     "DEBUG manager: Successfully initialized Derelict::Plugin::Manager for test instance\n"
   ]}
+
+  describe "#list" do
+    let(:stdout) { "stdout\n" }
+    let(:result) { double("result", :stdout => stdout) }
+    let(:parser) { double("parser", :plugins => plugins) }
+    let(:plugins) { [:foo, :bar] }
+
+    subject { manager.list }
+
+    before do
+      expect(instance).to receive(:execute!).with(:plugin, "list").and_return(result)
+      expect(Derelict::Parser::PluginList).to receive(:new).with(stdout).and_return(parser)
+    end
+
+    it { should be plugins }
+  end
 end

--- a/spec/derelict/plugin/not_found_spec.rb
+++ b/spec/derelict/plugin/not_found_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe Derelict::Plugin::NotFound do
+  subject { Derelict::Plugin::NotFound.new "test" }
+
+  it "is autoloaded" do
+    should be_a Derelict::Plugin::NotFound
+  end
+
+  its(:message) {
+    should eq "Plugin 'test' is not currently installed"
+  }
+end

--- a/spec/derelict/plugin_spec.rb
+++ b/spec/derelict/plugin_spec.rb
@@ -12,4 +12,26 @@ describe Derelict::Plugin do
 
   its(:name) { should be name }
   its(:version) { should be version }
+
+  context "when comparing to an equivalent" do
+    let(:other) { plugin.dup }
+
+    it { should eq other }
+    its(:hash) { should eq other.hash }
+
+    specify "#eql?(other) should be true" do
+      expect(subject.eql? other).to be true
+    end
+  end
+
+  context "when comparing to a non-equivalent" do
+    let(:other) { plugin.class.new "not_foo", "1.0" }
+
+    it { should_not eq other }
+    its(:hash) { should_not eq other.hash }
+
+    specify "#eql?(other) should be false" do
+      expect(subject.eql? other).to be false
+    end
+  end
 end

--- a/spec/derelict/plugin_spec.rb
+++ b/spec/derelict/plugin_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe Derelict::Plugin do
+  let(:name) { double("name") }
+  let(:version) { double("version") }
+  let(:plugin) { Derelict::Plugin.new name, version }
+  subject { plugin }
+
+  it "is autoloaded" do
+    should be_a Derelict::Plugin
+  end
+
+  its(:name) { should be name }
+  its(:version) { should be version }
+end


### PR DESCRIPTION
- Add `Derelict::Plugin`
  - Contains a name and version
  - Represents a Vagrant plugin
- Add `Derelict::Plugin::Manager`
  - Install/uninstall/update plugins for a particular instance
  - Check if a plugin is installed
  - Retrieve a list of `Derelict::Plugin` objects representing currently-installed plugins
- Add `Derelict::Instance#plugins` to get a `Derelict::Plugin::Manager` for the instance
