### PR TITLE
Add box manager

### DIFF
--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -9,6 +9,7 @@ Log4r::Logger["root"] # creates the level constants (INFO, etc).
 
 # Main module/entry point for Derelict
 module Derelict
+  autoload :Box,            "derelict/box"
   autoload :Connection,     "derelict/connection"
   autoload :Exception,      "derelict/exception"
   autoload :Instance,       "derelict/instance"

--- a/lib/derelict/box.rb
+++ b/lib/derelict/box.rb
@@ -1,6 +1,8 @@
 module Derelict
   # Represents an individual Vagrant box for a particular provider
   class Box
+    autoload :NotFound, "derelict/box/not_found"
+
     attr_reader :name, :provider
 
     # Initializes a box with a particular name and provider

--- a/lib/derelict/box.rb
+++ b/lib/derelict/box.rb
@@ -1,0 +1,26 @@
+module Derelict
+  # Represents an individual Vagrant box for a particular provider
+  class Box
+    attr_reader :name, :provider
+
+    # Initializes a box with a particular name and provider
+    #
+    #   * name:     The name of the box represented by this object
+    #   * provider: The provider of the box represented by this object
+    def initialize(name, provider)
+      @name = name
+      @provider = provider
+    end
+
+    # Ensure equivalent Boxes are equal to this one
+    def ==(other)
+      other.name == name and other.provider == provider
+    end
+    alias_method :eql?, :==
+
+    # Make equivalent Boxes hash to the same value
+    def hash
+      name.hash ^ provider.hash
+    end
+  end
+end

--- a/lib/derelict/box.rb
+++ b/lib/derelict/box.rb
@@ -1,6 +1,7 @@
 module Derelict
   # Represents an individual Vagrant box for a particular provider
   class Box
+    autoload :Manager,  "derelict/box/manager"
     autoload :NotFound, "derelict/box/not_found"
 
     attr_reader :name, :provider

--- a/lib/derelict/box/manager.rb
+++ b/lib/derelict/box/manager.rb
@@ -1,0 +1,60 @@
+module Derelict
+  class Box
+    # A class that handles managing boxes for a Vagrant instance
+    class Manager
+      # Include "memoize" class method to memoize methods
+      extend Memoist
+
+      # Include "logger" method to get a logger for this class
+      include Utils::Logger
+
+      attr_reader :instance
+
+      # Initializes a Manager for use with a particular instance
+      #
+      #   * instance: The Derelict::Instance which will have its
+      #               boxes managed by this Manager
+      def initialize(instance)
+        @instance = instance
+        logger.debug "Successfully initialized #{description}"
+      end
+
+      # Retrieves the Set of currently installed boxes
+      def list
+        logger.info "Retrieving Vagrant box list for #{description}"
+        output = instance.execute!(:box, "list").stdout
+        Derelict::Parser::BoxList.new(output).boxes
+      end
+      memoize :list
+
+      # Determines whether a particular box is installed
+      #
+      #   * box_name: Name of the box to look for (as a string)
+      def present?(box_name, provider)
+        fetch(box_name, provider)
+        true
+      rescue Box::NotFound
+        false
+      end
+
+      # Retrieves a box with a particular name
+      #
+      #   * box_name: Name of the box to look for (as a string)
+      def fetch(box_name, provider)
+        box = list.find do |box|
+          box.name == box_name && box.provider == provider
+        end
+
+        raise Box::NotFound.new box_name, provider if box.nil?
+        box
+      end
+
+      # Provides a description of this Connection
+      #
+      # Mainly used for log messages.
+      def description
+        "Derelict::Box::Manager for #{instance.description}"
+      end
+    end
+  end
+end

--- a/lib/derelict/box/manager.rb
+++ b/lib/derelict/box/manager.rb
@@ -37,6 +37,56 @@ module Derelict
         false
       end
 
+      # Adds a box from a file or URL
+      #
+      # The provider will be automatically determined from the box
+      # file's manifest.
+      #
+      #   * box_name: The name of the box to add (e.g. "precise64")
+      #   * source:   The URL or path to the box file
+      #   * options:  Hash of options. Valid keys:
+      #      * log:   Whether to log the output (optional, defaults to
+      #               false)
+      def add(box_name, source, options)
+        options = {:log => false}.merge(options)
+        logger.info <<-END.gsub(/ {10}|\n\Z/, '')
+          Adding box '#{box_name}' from '#{source}' using #{description}
+        END
+
+        command = [:box, "add", box_name, source]
+
+        log_block = options[:log] ? shell_log_block : nil
+        instance.execute!(*command, &log_block).tap do
+          flush_cache # flush memoized method return values
+        end
+      end
+
+      # Removes an installed box for a particular provider
+      #
+      #   * box_name:    Name of the box to remove (e.g. "precise64")
+      #   * options:     Hash of options. Valid keys:
+      #      * log:      Whether to log the output (optional, defaults
+      #                  to false)
+      #      * provider: If specified, only the box for a particular
+      #                  provider is removed; otherwise (by default),
+      #                  the box is removed for all providers
+      def remove(box_name, options)
+        options = {:log => false, :provider => nil}.merge(options)
+
+        provider = options[:provider]
+        command = [:box, "remove", box_name]
+        command << provider unless provider.nil?
+
+        logger.info <<-END.gsub(/ {10}|\n\Z/, '')
+          Removing box '#{box_name}' for '#{provider}' using #{description}
+        END
+
+        log_block = options[:log] ? shell_log_block : nil
+        instance.execute!(*command, &log_block).tap do
+          flush_cache # flush memoized method return values
+        end
+      end
+
       # Retrieves a box with a particular name
       #
       #   * box_name: Name of the box to look for (as a string)

--- a/lib/derelict/box/not_found.rb
+++ b/lib/derelict/box/not_found.rb
@@ -1,0 +1,16 @@
+module Derelict
+  class Box
+    # A box that isn't currently installed has been retrieved
+    class NotFound < Derelict::Exception
+      # Initializes a new instance, for a particular box name/provider
+      #
+      #   * box_name: The name of the box that this exception relates
+      #               to
+      #   * provider: The provider of the box that this exception
+      #               relates to
+      def initialize(box_name, provider)
+        super "Box '#{box_name}' for provider '#{provider}' missing"
+      end
+    end
+  end
+end

--- a/lib/derelict/instance.rb
+++ b/lib/derelict/instance.rb
@@ -102,6 +102,12 @@ module Derelict
       Derelict::Plugin::Manager.new(self)
     end
 
+    # Initializes a box manager for use with this instance
+    def boxes
+      logger.info "Creating box manager for #{description}"
+      Derelict::Box::Manager.new(self)
+    end
+
     # Provides a description of this Instance
     #
     # Mainly used for log messages.

--- a/lib/derelict/parser.rb
+++ b/lib/derelict/parser.rb
@@ -1,6 +1,7 @@
 module Derelict
   # Base class for parsers, which extract data from command output
   class Parser
+    autoload :BoxList,    "derelict/parser/box_list"
     autoload :PluginList, "derelict/parser/plugin_list"
     autoload :Status,     "derelict/parser/status"
     autoload :Version,    "derelict/parser/version"

--- a/lib/derelict/parser/box_list.rb
+++ b/lib/derelict/parser/box_list.rb
@@ -2,5 +2,51 @@ module Derelict
   # Parses the output of "vagrant box list"
   class Parser::BoxList < Parser
     autoload :InvalidFormat, "derelict/parser/box_list/invalid_format"
+
+    # Include "memoize" class method to memoize methods
+    extend Memoist
+
+    # Output from "vagrant box list" if there are no boxes installed
+    NO_BOXES = <<-END.gsub(/^ {6}/, '')
+      There are no installed boxes! Use `vagrant box add` to add some.
+    END
+
+    # Regexp to parse a box line into a box name and provider
+    #
+    # Capture groups:
+    #
+    #   1. Box name, as listed in the output
+    #   2. Name of the provider for that box
+    PARSE_BOX = %r[
+      ^(.*)    # Box name starts at the start of the line
+      \ \(     # Provider is separated by a space and open-parenthesis
+        (.*)   # Provider name
+      \)$      # Ends with close-parenthesis and end-of-line
+    ]x         # Ignore whitespace to allow these comments
+
+    # Retrieves a Set containing all the boxes from the output
+    def boxes
+      box_lines.map {|l| parse_line l.match(PARSE_BOX) }.to_set
+    end
+
+    # Provides a description of this Parser
+    #
+    # Mainly used for log messages.
+    def description
+      "Derelict::Parser::BoxList instance"
+    end
+
+    private
+      # Retrieves an array of the box lines in the output
+      def box_lines
+        return [] if output.match NO_BOXES
+        output.lines
+      end
+
+      # Parses a single line of the output into a Box object
+      def parse_line(match)
+        raise InvalidFormat.new "Couldn't parse box list" if match.nil?
+        Derelict::Box.new *match.captures[0..1]
+      end
   end
 end

--- a/lib/derelict/parser/box_list.rb
+++ b/lib/derelict/parser/box_list.rb
@@ -1,0 +1,6 @@
+module Derelict
+  # Parses the output of "vagrant box list"
+  class Parser::BoxList < Parser
+    autoload :InvalidFormat, "derelict/parser/box_list/invalid_format"
+  end
+end

--- a/lib/derelict/parser/box_list/invalid_format.rb
+++ b/lib/derelict/parser/box_list/invalid_format.rb
@@ -1,0 +1,16 @@
+module Derelict
+  class Parser
+    class BoxList
+      # The box list wasn't in the expected format, can't be parsed
+      class InvalidFormat < Derelict::Exception
+        include Derelict::Exception::OptionalReason
+
+        private
+          # Retrieves the default error message
+          def default_message
+            "Output from 'vagrant box list' was in an unexpected format"
+          end
+      end
+    end
+  end
+end

--- a/lib/derelict/plugin/manager.rb
+++ b/lib/derelict/plugin/manager.rb
@@ -102,15 +102,6 @@ module Derelict
       def description
         "Derelict::Plugin::Manager for #{instance.description}"
       end
-
-      private
-        # A block that can be passed to #execute to log the output
-        def shell_log_block
-          Proc.new do |line|
-            logger(:type => :external).info line
-          end
-        end
-        memoize :shell_log_block
     end
   end
 end

--- a/lib/derelict/utils/logger.rb
+++ b/lib/derelict/utils/logger.rb
@@ -20,6 +20,13 @@ module Derelict
       end
 
       private
+        # A block that can be passed to #execute to log the output
+        def shell_log_block
+          Proc.new do |line|
+            logger(:type => :external).info line
+          end
+        end
+
         # Finds or creates a Logger with a particular fullname
         def find_or_create_logger(fullname)
           Log4r::Logger[fullname.to_s] || Log4r::Logger.new(fullname.to_s)

--- a/spec/derelict/box/manager_spec.rb
+++ b/spec/derelict/box/manager_spec.rb
@@ -63,6 +63,70 @@ describe Derelict::Box::Manager do
     ]}
   end
 
+  describe "#add" do
+    let(:log) { true }
+    let(:box_name) { double("box_name", :to_s => "test box") }
+    let(:source) { double("source", :to_s => "test source") }
+    let(:result) { double("result") }
+    subject { manager.add box_name, source, :log => log }
+
+    before do
+      expect(instance).to receive(:execute!).with(:box, "add", box_name, source).and_yield("test").and_return(result)
+    end
+
+    it { should be result }
+
+    context "with logging enabled" do
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n",
+        " INFO manager: Adding box 'test box' from 'test source' using Derelict::Box::Manager for test instance\n",
+        " INFO external: test\n",
+      ]}
+    end
+
+    context "with logging disabled" do
+      let(:log) { false }
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n",
+        " INFO manager: Adding box 'test box' from 'test source' using Derelict::Box::Manager for test instance\n",
+      ]}
+    end
+  end
+
+  describe "#remove" do
+    let(:log) { true }
+    let(:box_name) { "test_box" }
+    let(:provider) { "provider_one" }
+    let(:result) { double("result") }
+    subject { manager.remove box_name, :provider => provider, :log => log }
+
+    before do
+      expect(instance).to receive(:execute!).with(:box, "remove", box_name, provider).and_yield("test").and_return(result)
+    end
+
+    it { should be result }
+
+    context "with logging enabled" do
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n",
+        " INFO manager: Removing box 'test_box' for 'provider_one' using Derelict::Box::Manager for test instance\n",
+        " INFO external: test\n",
+      ]}
+    end
+
+    context "with logging disabled" do
+      let(:log) { false }
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n",
+        " INFO manager: Removing box 'test_box' for 'provider_one' using Derelict::Box::Manager for test instance\n",
+      ]}
+    end
+  end
+
   describe "#fetch" do
     let(:foo) { double("foo", :name => "foo", :provider => "provider_one") }
     let(:bar) { double("bar", :name => "bar", :provider => "provider_two") }

--- a/spec/derelict/box/manager_spec.rb
+++ b/spec/derelict/box/manager_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+describe Derelict::Box::Manager do
+  let(:instance) { double("instance", :description => "test instance") }
+  let(:manager) { Derelict::Box::Manager.new instance }
+  subject { manager }
+
+  it "is autoloaded" do
+    should be_a Derelict::Box::Manager
+  end
+
+  include_context "logged messages"
+  let(:expected_logs) {[
+    "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n"
+  ]}
+
+  describe "#list" do
+    let(:stdout) { "stdout\n" }
+    let(:result) { double("result", :stdout => stdout) }
+    let(:parser) { double("parser", :boxes => boxes) }
+    let(:boxes) { [:foo, :bar] }
+
+    subject { manager.list }
+
+    before do
+      expect(instance).to receive(:execute!).with(:box, "list").and_return(result)
+      expect(Derelict::Parser::BoxList).to receive(:new).with(stdout).and_return(parser)
+    end
+
+    it { should be boxes }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n",
+      " INFO manager: Retrieving Vagrant box list for Derelict::Box::Manager for test instance\n",
+    ]}
+  end
+
+  describe "#present?" do
+    let(:box_name) { double("box_name") }
+    let(:box) { double("box", :provider => box_provider) }
+    let(:box_provider) { nil }
+    let(:provider) { nil }
+    subject { manager.present? box_name, provider }
+
+    context "with known box" do
+      before { expect(manager).to receive(:fetch).with(box_name, provider).and_return(box) }
+
+      let(:provider) { "provider_one" }
+      let(:box_provider) { "provider_one" }
+      it { should be true }
+    end
+
+    context "with unknown box" do
+      before { expect(manager).to receive(:fetch).with(box_name, provider).and_raise(Derelict::Box::NotFound.new box_name, provider) }
+      it { should be false }
+    end
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n",
+      " INFO manager: Retrieving Vagrant box list for Derelict::Box::Manager for test instance\n",
+    ]}
+  end
+
+  describe "#fetch" do
+    let(:foo) { double("foo", :name => "foo", :provider => "provider_one") }
+    let(:bar) { double("bar", :name => "bar", :provider => "provider_two") }
+    let(:boxes) { [foo, bar] }
+
+    let(:box_name) { double("box_name") }
+    let(:box_provider) { double("box_provider") }
+    subject { manager.fetch box_name, box_provider }
+    before { expect(manager).to receive(:list).and_return(boxes) }
+
+    context "with known box" do
+      let(:box_name) { "foo" }
+      let(:box_provider) { "provider_one" }
+      it { should be foo }
+    end
+
+    context "with unknown box" do
+      let(:box_name) { "qux" }
+      it "should raise NotFound" do
+        expect { subject }.to raise_error Derelict::Box::NotFound
+      end
+    end
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG manager: Successfully initialized Derelict::Box::Manager for test instance\n",
+    ]}
+  end
+
+end

--- a/spec/derelict/box/not_found_spec.rb
+++ b/spec/derelict/box/not_found_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe Derelict::Box::NotFound do
+  subject { Derelict::Box::NotFound.new "test", "provider_one" }
+
+  it "is autoloaded" do
+    should be_a Derelict::Box::NotFound
+  end
+
+  its(:message) {
+    should eq "Box 'test' for provider 'provider_one' missing"
+  }
+end

--- a/spec/derelict/box_spec.rb
+++ b/spec/derelict/box_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe Derelict::Box do
+  let(:name) { double("name") }
+  let(:provider) { double("provider") }
+  let(:box) { Derelict::Box.new name, provider }
+  subject { box }
+
+  it "is autoloaded" do
+    should be_a Derelict::Box
+  end
+
+  its(:name) { should be name }
+  its(:provider) { should be provider }
+
+  context "when comparing to an equivalent" do
+    let(:other) { box.dup }
+
+    it { should eq other }
+    its(:hash) { should eq other.hash }
+
+    specify "#eql?(other) should be true" do
+      expect(subject.eql? other).to be true
+    end
+  end
+
+  context "when comparing to a non-equivalent" do
+    let(:other) { box.class.new "not_foo", "other_provider" }
+
+    it { should_not eq other }
+    its(:hash) { should_not eq other.hash }
+
+    specify "#eql?(other) should be false" do
+      expect(subject.eql? other).to be false
+    end
+  end
+end

--- a/spec/derelict/instance_spec.rb
+++ b/spec/derelict/instance_spec.rb
@@ -31,6 +31,12 @@ describe Derelict::Instance do
     its(:instance) { should be instance }
   end
 
+  describe "#boxes" do
+    subject { instance.boxes }
+    it { should be_a Derelict::Box::Manager }
+    its(:instance) { should be instance }
+  end
+
   context "with path parameter" do
     let(:path) { "/foo/bar" }
 

--- a/spec/derelict/parser/box_list/invalid_format_spec.rb
+++ b/spec/derelict/parser/box_list/invalid_format_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe Derelict::Parser::BoxList::InvalidFormat do
+  it "is autoloaded" do
+    should be_a Derelict::Parser::BoxList::InvalidFormat
+  end
+
+  context "when using default reason" do
+    its(:message) { should eq "Output from 'vagrant box list' was in an unexpected format" }
+  end
+
+  context "when using custom reason" do
+    subject { Derelict::Parser::BoxList::InvalidFormat.new "reason" }
+    its(:message) { should eq "Output from 'vagrant box list' was in an unexpected format: reason" }
+  end
+end

--- a/spec/derelict/parser/box_list_spec.rb
+++ b/spec/derelict/parser/box_list_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+describe Derelict::Parser::BoxList do
+  subject { Derelict::Parser::BoxList.new output }
+  let(:output) { nil }
+
+  it "is autoloaded" do
+    should be_a Derelict::Parser::BoxList
+  end
+
+  describe "#boxes" do
+    subject { Derelict::Parser::BoxList.new(output).boxes }
+
+    include_context "logged messages"
+    let(:expected_logs) {[
+      "DEBUG boxlist: Successfully initialized Derelict::Parser::BoxList instance\n",
+    ]}
+
+    context "with valid output" do
+      let(:output) {
+        <<-END.gsub /^ +/, ""
+          foo (provider_one)
+          bar (provider_two)
+        END
+      }
+
+      let(:foo) { Derelict::Box.new "foo", "provider_one" }
+      let(:bar) { Derelict::Box.new "bar", "provider_two" }
+      it { should eq Set[foo, bar] }
+    end
+
+    context "with invalid output" do
+      let(:output) {
+        <<-END.gsub /^ +/, ""
+          foo (provider_one) lolwut
+          bar with no brackets
+        END
+      }
+
+      it "should raise InvalidFormat" do
+        expect { subject }.to raise_error Derelict::Parser::BoxList::InvalidFormat
+      end
+    end
+
+    context "with no boxes in list" do
+      let(:output) {
+        <<-END.gsub /^ +/, ""
+          There are no installed boxes! Use `vagrant box add` to add some.
+        END
+      }
+
+      it { should eq Set.new }
+    end
+  end
+end


### PR DESCRIPTION
Adds box management functionality to Derelict.
- Adds `Derelict::Box` class, to represent a specific box for a particular provider
- Adds `Derelict::Box::Manager`, to manage boxes
  - Get list of boxes with `#list`
  - Retrieve a box by name and provider with `#fetch`
  - Check if a box is added with `#present?`
  - Add a box from a source with `#add`
  - Remove a box with `#remove`
- Adds `#boxes` method to `Derelict::Instance` to get a box manager for the instance
