### PR TITLE
Avoid leaving Vagrant processes running when receiving an interrupt signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ instance = Derelict.instance("/path/to/vagrant")
 instance = Derelict.instance # Defaults to /Applications/Vagrant
 
 # Issue commands to the instance directly (not usually necessary)
-result = instance.execute('--version') # Shell::Executer object
+result = instance.execute('--version') # Derelict::Executer object
 print "success" if result.success?     # if Vagrant's exit status was 0
 print result.stdout                    # "Vagrant 1.3.3\n"
 
@@ -73,7 +73,7 @@ connection = instance.connect("/path/to/project")
 
 # Issue commands to the connection directly (runs from the project dir)
 result = connection.execute(:up) # runs "vagrant up" in project dir
-result.success?                  # it's a Shell::Executer object again
+result.success?                  # Derelict::Executer object again
 
 # Retrieve a particular VM from a connection (multi-machine support)
 vm = connection.vm(:web) # "vm" is a Derelict::VirtualMachine

--- a/derelict.gemspec
+++ b/derelict.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "log4r"
   spec.add_runtime_dependency "memoist"
-  spec.add_runtime_dependency "shell-executer"
 
 
   version_major = RbConfig::CONFIG["MAJOR"].to_i

--- a/derelict.gemspec
+++ b/derelict.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "log4r"
   spec.add_runtime_dependency "memoist"
+  spec.add_runtime_dependency "open4"
 
 
   version_major = RbConfig::CONFIG["MAJOR"].to_i

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -1,6 +1,7 @@
 require "derelict/version"
 require "log4r"
 require "memoist"
+require "open4"
 require "set"
 require "shellwords"
 

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -2,7 +2,6 @@ require "derelict/version"
 require "log4r"
 require "memoist"
 require "set"
-require "shell/executer"
 require "shellwords"
 
 Log4r::Logger["root"] # creates the level constants (INFO, etc).

--- a/lib/derelict.rb
+++ b/lib/derelict.rb
@@ -12,6 +12,7 @@ module Derelict
   autoload :Box,            "derelict/box"
   autoload :Connection,     "derelict/connection"
   autoload :Exception,      "derelict/exception"
+  autoload :Executer,       "derelict/executer"
   autoload :Instance,       "derelict/instance"
   autoload :Parser,         "derelict/parser"
   autoload :Plugin,         "derelict/plugin"

--- a/lib/derelict/connection.rb
+++ b/lib/derelict/connection.rb
@@ -48,7 +48,7 @@ module Derelict
     #
     #   * subcommand: Vagrant subcommand to run (:up, :status, etc.)
     #   * arguments:  Arguments to pass to the subcommand (optional)
-    #   * block:      Passed through to Shell.execute (shell-executer)
+    #   * block:      Passed through to Derelict::Executer.execute
     #
     # Raises +Derelict::Instance::CommandFailed+ if the command fails.
     def execute!(subcommand, *arguments, &block)

--- a/lib/derelict/executer.rb
+++ b/lib/derelict/executer.rb
@@ -1,0 +1,173 @@
+module Derelict
+  # Executes an external (shell) command "safely"
+  #
+  # The safety involved is mainly ensuring that the command is
+  # gracefully terminated if this process is about to terminate.
+  class Executer
+    attr_reader :stdout, :stderr, :success
+
+    # Executes <tt>command</tt> and returns after execution
+    #
+    #   * command: A string containing the command to run
+    #   * options: A hash of options, with the following (symbol) keys:
+    #      * :mode:      Controls how the process' output is given to
+    #                    the block, one of :chars (pass each character
+    #                    one by one, retrieved with getc), or :lines
+    #                    (pass only whole lines, retrieved with gets).
+    #                    (optional, defaults to :lines)
+    #      * :no_buffer: If true, the process' stdout and stderr won't
+    #                    be collected in the stdout and stderr
+    #                    properties, and will only be passed to the
+    #                    block (optional, defaults to false)
+    #   * block:   Gets passed stdout and stderr every time the process
+    #              outputs to each stream (first parameter is stdout,
+    #              second parameter is stderr; only one will contain
+    #              data, the other will be nil)
+    def self.execute(command, options = {}, &block)
+      self.new(options).execute(command, &block)
+    end
+
+
+    # Initializes an Executer instance with particular options
+    #
+    #   * options: A hash of options, with the following (symbol) keys:
+    #      * :mode:      Controls how the process' output is given to
+    #                    the block, one of :chars (pass each character
+    #                    one by one, retrieved with getc), or :lines
+    #                    (pass only whole lines, retrieved with gets).
+    #                    (optional, defaults to :lines)
+    #      * :no_buffer: If true, the process' stdout and stderr won't
+    #                    be collected in the stdout and stderr
+    #                    properties, and will only be passed to the
+    #                    block (optional, defaults to false)
+    def initialize(options = {})
+      @options = {:mode => :lines, :no_buffer => false}.merge(options)
+
+      if @options[:mode] == :chars
+        @reader = proc {|s| s.getc }
+      else
+        @reader = proc {|s| s.gets }
+      end
+
+      @mutex = Mutex.new
+      reset
+    end
+
+    # Executes <tt>command</tt> and returns after execution
+    #
+    #   * command: A string containing the command to run
+    #   * block:   Gets passed stdout and stderr every time the process
+    #              outputs to each stream (first parameter is stdout,
+    #              second parameter is stderr; only one will contain
+    #              data, the other will be nil)
+    def execute(command, &block)
+      reset
+      pid, stdin, stdout, stderr = Open4::popen4(command)
+
+      save_exit_status(pid)
+      forward_signals_to(pid) { handle_streams stdout, stderr, &block }
+      self
+    end
+
+
+    private
+      # Clears the variables relating to a particular command execution
+      #
+      # This is done when first initialising, and just before a command
+      # is run, to get rid of the previous command's data.
+      def reset
+        @stdout = ''
+        @stderr = ''
+        @success = nil
+      end
+
+      # Waits for the exit status of a process (in a thread) saving it
+      #
+      # This will set the @status instance variable to true if the exit
+      # status was 0, or false if the exit status was anything else.
+      def save_exit_status(pid)
+        Thread.start do
+          @success = nil
+          @success = (Process.waitpid2(pid).last.exitstatus == 0)
+        end
+      end
+
+      # Forward signals to a process while running the given block
+      #
+      #   * pid:     The process ID to forward signals to
+      #   * signals: The names of the signals to handle (optional,
+      #              defaults to SIGINT only)
+      def forward_signals_to(pid, signals = %w[INT])
+        # Set up signal handlers
+        signals.each do |signal|
+          Signal.trap(signal) { Process.kill signal, pid }
+        end
+
+        # Run the block now that the signals are being forwarded
+        yield
+
+        # Reset signal handlers
+        signals.each do |signal|
+          Signal.trap signal, "DEFAULT"
+        end
+      end
+
+      # Manages reading from the stdout and stderr streams
+      #
+      #   * stdout: The process' stdout stream
+      #   * stderr: The process' stderr stream
+      #   * block:  The block to pass any read data to (optional)
+      def handle_streams(stdout, stderr, &block)
+        streams = [stdout, stderr]
+        until streams.empty?
+          # Find which streams are ready for reading, timeout 0.1s
+          selected, = select(streams, nil, nil, 0.1)
+
+          # Try again if none were ready
+          next if selected.nil? or selected.empty?
+
+          selected.each do |stream|
+            if stream.eof?
+              streams.delete(stream) unless @success.nil?
+              next
+            end
+
+            while data = @reader.call(stream)
+              data = ((@options[:mode] == :chars) ? data.chr : data)
+              stream_name = (stream == stdout) ? :stdout : :stderr
+              output data, stream_name, &block unless block.nil?
+            end
+          end
+        end
+      end
+
+      # Outputs data to the block
+      #
+      #   * data:        The data that needs to be passed to the block
+      #   * stream_name: The stream data came from (:stdout or :stderr)
+      #   * block:       The block to pass the data to
+      def output(data, stream_name = :stdout, &block)
+        # Pass the output to the block
+        if block.arity == 2
+          args = [nil, nil]
+          if stream_name == :stdout
+            args[0] = data
+          else
+            args[1] = data
+          end
+          block.call(*args)
+        else
+          yield data if stream_name == :stdout
+        end
+
+        # Add to the buffers
+        unless @options[:no_buffer]
+          if stream_name == :stdout
+            @stdout += data
+          else
+            @stderr += data
+          end
+        end
+      end
+  end
+end

--- a/lib/derelict/instance.rb
+++ b/lib/derelict/instance.rb
@@ -72,7 +72,7 @@ module Derelict
       command = command(subcommand, *arguments)
       command = "sudo -- #{command}" if options.delete(:sudo)
       logger.debug "Executing #{command} using #{description}"
-      Shell.execute command, options, &block
+      Executer.execute command, options, &block
     end
 
     # Executes a Vagrant subcommand, raising an exception on failure

--- a/lib/derelict/instance.rb
+++ b/lib/derelict/instance.rb
@@ -62,11 +62,11 @@ module Derelict
     #                 as a hash of options. A list of valid options is
     #                 below. Any options provided that aren't in the
     #                 list of valid options will get passed through to
-    #                 Shell.execute (from the "shell-executer" gem).
+    #                 Derelict::Executer.execute.
     #                 Valid option keys:
     #      * sudo:    Whether to run the command as root, or not
     #                 (defaults to false)
-    #   * block:      Passed through to Shell.execute (shell-executer)
+    #   * block:      Passed through to Derelict::Executer.execute
     def execute(subcommand, *arguments, &block)
       options = arguments.last.is_a?(Hash) ? arguments.pop : Hash.new
       command = command(subcommand, *arguments)
@@ -79,7 +79,7 @@ module Derelict
     #
     #   * subcommand: Vagrant subcommand to run (:up, :status, etc.)
     #   * arguments:  Arguments to pass to the subcommand (optional)
-    #   * block:      Passed through to Shell.execute (shell-executer)
+    #   * block:      Passed through to Derelict::Executer.execute
     #
     # Raises +Derelict::Instance::CommandFailed+ if the command fails.
     def execute!(subcommand, *arguments, &block)

--- a/lib/derelict/instance/command_failed.rb
+++ b/lib/derelict/instance/command_failed.rb
@@ -2,11 +2,13 @@ module Derelict
   class Instance
     # Represents an invalid instance, which can't be used with Derelict
     class CommandFailed < Derelict::Exception
-      # Initializes a new instance of this exception, with a reason
+      # Initializes a new instance of this exception, for a command
       #
-      #   * reason: The result (Shell::Executer) for the command that
-      #             failed (optional, provides extra detail in the
-      #             message)
+      #   * command: The name of the command which failed (optional,
+      #              provides extra detail in the message)
+      #   * result:  The result (Derelict::Executer) for the command
+      #              which failed (optional, provides extra detail in
+      #              the message)
       def initialize(command = nil, result = nil)
         super [default_message, describe(command, result)].join
       end

--- a/spec/derelict/executer_spec.rb
+++ b/spec/derelict/executer_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+
+describe Derelict::Executer do
+  let(:executer) { described_class.new }
+  let(:command) { double("command") }
+  let(:options) { Hash.new }
+  let(:block) { Proc.new do end }
+  let(:result) { double("result") }
+
+  describe ".execute" do
+    before do
+      expect(described_class).to receive(:new).with(options).and_return(executer)
+      expect(executer).to receive(:execute).with(command, &block).and_return(result)
+    end
+
+    subject { described_class.execute command, options, &block }
+    it { should be result }
+  end
+
+  describe "#initialize" do
+    subject { described_class.new options }
+    it { should be_a described_class }
+    its(:stdout) { should eq "" }
+    its(:stderr) { should eq "" }
+    its(:success) { should be_nil }
+
+    context "with :chars mode specified" do
+      let(:options) { {:mode => :chars} }
+      it { should be_a described_class }
+    end
+  end
+
+  # The way #execute is tested is much slower than a unit test
+  # (obviously), but I ran into some difficulty implementing a proper
+  # unit test for this method.
+  #
+  # TODO: rewrite as a unit test
+  describe "#execute" do
+    subject { executer.execute command, &block }
+
+    context "without a block" do
+      let(:command) { "echo 'test 1'" }
+      its(:stdout) { should eq "test 1\n" }
+      its(:stderr) { should eq "" }
+      its(:success) { should be_true }
+
+      context "with non-existent command" do
+        let(:command) { "not_actually_a_command" }
+        it "should raise ENOENT" do
+          expect { subject }.to raise_error(Errno::ENOENT)
+        end
+      end
+
+      context "with unsuccessful command" do
+        let(:command) { "false" }
+        its(:success) { should be_false }
+      end
+    end
+
+    context "with a block" do
+      context "with one argument" do
+        let(:command) { "echo 'test 2'" }
+        let(:block) do
+          @buffer = ""
+          Proc.new do |stdout|
+            @buffer << stdout
+          end
+        end
+
+        its(:stdout) { should eq "test 2\n" }
+        its(:stderr) { should eq "" }
+        its(:success) { should be_true }
+        specify "the block should get called" do
+          subject; expect(@buffer).to eq executer.stdout
+        end
+      end
+
+      context "with two arguments" do
+        let(:command) { "echo 'test 3'; echo 'test 4' 1>&2" }
+        let(:block) do
+          @stdout = ""; @stderr = ""
+          Proc.new do |stdout, stderr|
+            @stdout << stdout unless stdout.nil?
+            @stderr << stderr unless stderr.nil?
+          end
+        end
+
+        its(:stdout) { should eq "test 3\n" }
+        its(:stderr) { should eq "test 4\n" }
+        its(:success) { should be_true }
+        specify "the block should get called" do
+          subject
+          expect(@stdout).to eq executer.stdout
+          expect(@stderr).to eq executer.stderr
+        end
+      end
+    end
+  end
+end

--- a/spec/derelict/instance_spec.rb
+++ b/spec/derelict/instance_spec.rb
@@ -165,10 +165,10 @@ describe Derelict::Instance do
       ]}
     end
 
-    context "with mock Shell" do
+    context "with mock Executer" do
       let(:expected_command) { "/foo/bar/bin/vagrant test arg\\ 1" }
       before do
-        expect(Shell).to receive(:execute).with(expected_command, options).and_return(result)
+        expect(Derelict::Executer).to receive(:execute).with(expected_command, options).and_return(result)
       end
 
       let(:options) { Hash.new }
@@ -207,7 +207,7 @@ describe Derelict::Instance do
 
         context "with :sudo option enabled" do
           let(:options_argument) { {:sudo => true} }
-          let(:options) { Hash.new } # Don't pass sudo opt to Shell.execute
+          let(:options) { Hash.new } # Don't pass sudo opt to Executer.execute
           let(:expected_command) { "sudo -- /foo/bar/bin/vagrant test arg\\ 1" }
           subject { instance.execute :test, "arg 1", options_argument }
           its(:stdout) { should eq "stdout\n" }


### PR DESCRIPTION
Previous versions were naive; when the Derelict process was killed (e.g. Ctrl-C sending SIGINT), if Derelict was currently waiting for a Vagrant process to finish, it would leave the Vagrant process running. The user would then either have to kill Vagrant manually or be frustrated and wonder why other Vagrant instances said "another instance of Vagrant is operating on this machine" etc.

This change ensures that while Derelict is waiting for Vagrant to finish, any SIGINT signals get forwarded to the Vagrant process. Vagrant uses a similar mechanism internally when executing commands.
