### PR TITLE
Raise different exception for plugins needing reinstallation

### DIFF
--- a/lib/derelict/parser/plugin_list.rb
+++ b/lib/derelict/parser/plugin_list.rb
@@ -20,9 +20,21 @@ module Derelict
       $                # at the end of the line.
     ]x                 # Ignore whitespace to allow these comments.
 
+    # Regexp to determine whether plugins need to be reinstalled
+    NEEDS_REINSTALL = %r[
+      ^The\splugins\sbelow\swill\snot\sbe\sloaded\suntil\sthey're\s
+      uninstalled\sand\sreinstalled:$
+    ]x
+
     # Retrieves a Set containing all the plugins from the output
     def plugins
+      raise NeedsReinstall, output if needs_reinstall?
       plugin_lines.map {|l| parse_line l.match(PARSE_PLUGIN) }.to_set
+    end
+
+    # Determines if old plugins need to be reinstalled
+    def needs_reinstall?
+      output =~ NEEDS_REINSTALL
     end
 
     # Provides a description of this Parser

--- a/lib/derelict/parser/plugin_list.rb
+++ b/lib/derelict/parser/plugin_list.rb
@@ -2,6 +2,7 @@ module Derelict
   # Parses the output of "vagrant plugin list"
   class Parser::PluginList < Parser
     autoload :InvalidFormat, "derelict/parser/plugin_list/invalid_format"
+    autoload :NeedsReinstall, "derelict/parser/plugin_list/needs_reinstall"
 
     # Include "memoize" class method to memoize methods
     extend Memoist

--- a/lib/derelict/parser/plugin_list/needs_reinstall.rb
+++ b/lib/derelict/parser/plugin_list/needs_reinstall.rb
@@ -1,0 +1,22 @@
+module Derelict
+  class Parser
+    class PluginList
+      # Vagrant plugins need to be uninstalled and re-installed
+      class NeedsReinstall < Derelict::Exception
+        # Retrieves the output from Vagrant
+        attr_reader :output
+
+        # Initializes a new instance, for a particular box name/provider
+        #
+        #   * output: The output from Vagrant
+        def initialize(output)
+          @output = output
+          super <<-END.gsub(/\s+/, ' ').strip
+            Vagrant plugins installed before upgrading to version 1.4.x
+            need to be uninstalled and re-installed.
+          END
+        end
+      end
+    end
+  end
+end

--- a/lib/derelict/version.rb
+++ b/lib/derelict/version.rb
@@ -1,3 +1,3 @@
 module Derelict
-  VERSION = "0.4.5"
+  VERSION = "0.5.0"
 end

--- a/spec/derelict/parser/plugin_list/needs_reinstall_spec.rb
+++ b/spec/derelict/parser/plugin_list/needs_reinstall_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+describe Derelict::Parser::PluginList::NeedsReinstall do
+  let(:output) { double("output") }
+  subject { Derelict::Parser::PluginList::NeedsReinstall.new output }
+
+  it "is autoloaded" do
+    should be_a Derelict::Parser::PluginList::NeedsReinstall
+  end
+
+  its(:message) { should eq "Vagrant plugins installed before upgrading to version 1.4.x need to be uninstalled and re-installed." }
+  its(:output) { should be output }
+end

--- a/spec/derelict/parser/plugin_list_spec.rb
+++ b/spec/derelict/parser/plugin_list_spec.rb
@@ -28,4 +28,42 @@ describe Derelict::Parser::PluginList do
       ]}
     end
   end
+
+  context "with plugins needing re-install" do
+    let(:output) {
+      <<-END.gsub /^ {8}/, ""
+        The following plugins were installed with a version of Vagrant
+        that had different versions of underlying components. Because
+        these component versions were changed (which rarely happens),
+        the plugins must be uninstalled and reinstalled.
+
+        To ensure that all the dependencies are properly updated as well
+        it is _highly recommended_ to do a `vagrant plugin uninstall`
+        prior to reinstalling.
+
+        This message will not go away until all the plugins below are
+        either uninstalled or uninstalled then reinstalled.
+
+        The plugins below will not be loaded until they're uninstalled
+        and reinstalled:
+
+        foo, bar
+        foo (2.3.4)
+        bar (1.2.3)
+      END
+    }
+
+    describe "#plugins" do
+      subject { Derelict::Parser::PluginList.new(output).plugins }
+
+      it "should raise NeedsReinstall" do
+        expect { subject }.to raise_error(Derelict::Parser::PluginList::NeedsReinstall)
+      end
+
+      include_context "logged messages"
+      let(:expected_logs) {[
+        "DEBUG pluginlist: Successfully initialized Derelict::Parser::PluginList instance\n",
+      ]}
+    end
+  end
 end


### PR DESCRIPTION
Raise `Derelict::Parser::PluginList::NeedsReinstall` if plugins need to be reinstalled.
