### PR TITLE
Vagrant 1.5 plugin list has extra params

### DIFF
--- a/lib/derelict/parser/plugin_list.rb
+++ b/lib/derelict/parser/plugin_list.rb
@@ -14,11 +14,11 @@ module Derelict
     #   1. Plugin name, as listed in the output
     #   2. Currently installed version (without surrounding brackets)
     PARSE_PLUGIN = %r[
-      ^(.*)            # Plugin name starts at the start of the line.
-      \                # Version is separated by a space character,
-      \(([0-9\-_.]+)\) # contains version string surrounded by brackets
-      $                # at the end of the line.
-    ]x                 # Ignore whitespace to allow these comments.
+      ^(.*)                  # Plugin name starts at the start of the line.
+      \                      # Version is separated by a space character,
+      \(([0-9\-_.]+)(, .*)?\) # contains version string surrounded by brackets
+      $                      # at the end of the line.
+    ]x                       # Ignore whitespace to allow these comments.
 
     # Regexp to determine whether plugins need to be reinstalled
     NEEDS_REINSTALL = %r[

--- a/spec/derelict/parser/plugin_list_spec.rb
+++ b/spec/derelict/parser/plugin_list_spec.rb
@@ -12,7 +12,7 @@ describe Derelict::Parser::PluginList do
     let(:output) {
       <<-END.gsub /^ +/, ""
         foo (2.3.4)
-        bar (1.2.3)
+        bar (1.2.3, system)
       END
     }
 


### PR DESCRIPTION
This updates the regex so we can still parse the version, but ignores the extra params
