### PR TITLE
support for obtaining the raw status code from an executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ instance = Derelict.instance # Defaults to /Applications/Vagrant
 result = instance.execute('--version') # Derelict::Executer object
 print "success" if result.success?     # if Vagrant's exit status was 0
 print result.stdout                    # "Vagrant 1.3.3\n"
+print result.status                    # 0
 
 # Connect to a Vagrant project (containing a Vagrantfile)
 connection = instance.connect("/path/to/project")

--- a/derelict.gemspec
+++ b/derelict.gemspec
@@ -44,8 +44,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "cane" if cane_supported
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rake", "< 11.0"
+  spec.add_development_dependency "rspec", "< 3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "its"
   spec.add_development_dependency "mime-types", "<2.0" # for coveralls

--- a/derelict.gemspec
+++ b/derelict.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "derelict/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "derelict"
+  spec.name          = "derelict_m"
   spec.version       = Derelict::VERSION
   spec.authors       = ["Brad Feehan"]
   spec.email         = ["git@bradfeehan.com"]

--- a/lib/derelict/executer.rb
+++ b/lib/derelict/executer.rb
@@ -93,6 +93,14 @@ module Derelict
       @success
     end
 
+    # Return the real exit status of the last command as it was returned to
+    # the system.  This is useful if your doing things like running commands
+    # inside a vm over ssh and want to obtain the exit status from the command
+    # itself.  If a command is currently running, this will return nil.
+    def status
+      @status
+    end
+
     private
       # Clears the variables relating to a particular command execution
       #
@@ -103,6 +111,7 @@ module Derelict
         @stdout = ''
         @stderr = ''
         @success = nil
+        @status = nil
         @pid = nil
       end
 
@@ -115,9 +124,9 @@ module Derelict
         @success = nil
         Thread.start do
           logger.debug "Thread started, waiting for PID #{pid}"
-          status = Process.waitpid2(pid).last.exitstatus
-          logger.debug "Process exited with status #{status}"
-          @success = (status == 0)
+          @status = Process.waitpid2(pid).last.exitstatus
+          logger.debug "Process exited with status #{@status}"
+          @success = (@status == 0)
         end
       end
 

--- a/lib/derelict/version.rb
+++ b/lib/derelict/version.rb
@@ -1,3 +1,3 @@
 module Derelict
-  VERSION = "0.6.2"
+  VERSION = "0.6.2a"
 end

--- a/spec/derelict/executer_spec.rb
+++ b/spec/derelict/executer_spec.rb
@@ -23,6 +23,7 @@ describe Derelict::Executer do
     its(:stdout) { should eq "" }
     its(:stderr) { should eq "" }
     its(:success?) { should be_nil }
+    its(:status) { should be_nil }
 
     context "with :chars mode specified" do
       let(:options) { {:mode => :chars} }
@@ -43,6 +44,7 @@ describe Derelict::Executer do
       its(:stdout) { should eq "test 1\n" }
       its(:stderr) { should eq "" }
       its(:success?) { should be_true }
+      its(:status) { should be 0 }
 
       context "with non-existent command" do
         let(:command) { "not_actually_a_command" }
@@ -54,6 +56,7 @@ describe Derelict::Executer do
       context "with unsuccessful command" do
         let(:command) { "false" }
         its(:success?) { should be_false }
+        its(:status) { should be 1 }
       end
 
       # Unfortunately this part is even worse. It seems to work though!
@@ -77,6 +80,7 @@ describe Derelict::Executer do
 
         specify "the sub-process should get killed" do
           expect(subject.success?).to be_false
+          expect(subject.status).to be nil
         end
       end
     end
@@ -94,6 +98,7 @@ describe Derelict::Executer do
         its(:stdout) { should eq "test 2\n" }
         its(:stderr) { should eq "" }
         its(:success?) { should be_true }
+        its(:status) { should be 0 }
         specify "the block should get called" do
           subject; expect(@buffer).to eq executer.stdout
         end
@@ -112,6 +117,7 @@ describe Derelict::Executer do
         its(:stdout) { should eq "test 3\n" }
         its(:stderr) { should eq "test 4\n" }
         its(:success?) { should be_true }
+        its(:status) { should be 0 }
         specify "the block should get called" do
           subject
           expect(@stdout).to eq executer.stdout


### PR DESCRIPTION
Addresses #16 by providing a new method `status` on `Executors`.

Resolves all CI tests failing by pinning older versions of rspec and rake